### PR TITLE
fix(math): typo in phi angle calculation

### DIFF
--- a/math.js
+++ b/math.js
@@ -25,7 +25,7 @@ function isHit(shooter, target, direction) {
 
   // taking y axis into account.
   const phi =
-    direction < 0
+    direction.z < 0
       ? -Math.atan(direction.y / direction.z)
       : Math.atan(direction.y / direction.z);
 


### PR DESCRIPTION
I noticed there was a error in calculating the y angle. forgot to dot off the aim.  